### PR TITLE
fix(ci): remove duplicate GitHub Packages auth in manual release

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: "24.x"
 
-      - name: Authenticate Registry for install
+      - name: Authenticate Registry & Configure Git User
         run: |
           echo "@ethberry:registry=https://npm.pkg.github.com/" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=$GITHUBTOKEN" >> .npmrc
@@ -37,22 +37,6 @@ jobs:
 
       - name: Build Packages
         run: npm run build
-
-      - name: Authenticate GitHub Packages & Configure Git User
-        run: |
-          echo "@ethberry:registry=https://npm.pkg.github.com/" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=$GITHUBTOKEN" >> .npmrc
-          git update-index --assume-unchanged .npmrc
-          npx npm-cli-login -u $GITHUBUSER -p $GITHUBTOKEN -e $GITHUBEMAIL -r https://npm.pkg.github.com -s @ethberry --config-path="./"
-          git config --global user.name '@ethberry'
-          git config --global user.email $GITHUBEMAIL
-        env:
-          GITHUBTOKEN: ${{ secrets.GITHUBTOKEN }}
-          GITHUBUSER: ${{ secrets.GITHUBUSER }}
-          GITHUBEMAIL: ${{ secrets.GITHUBEMAIL }}
-
-      - name: Authenticate GitHub Packages via npm
-        run: npm whoami --registry=https://npm.pkg.github.com/
 
       - name: Version by NPM
         run: npm version patch -m "[Manual release] [skip ci] %s"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "jest": "30.4.2",
         "jest-environment-node": "30.4.1",
         "lint-staged": "16.4.0",
-        "prettier": "3.8.4",
+        "prettier": "3.8.5",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2",
@@ -8241,9 +8241,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
       "dev": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
## Summary
- Remove redundant GitHub Packages login before version bump in manual release
- Auth before `npm ci` already configures `.npmrc` for the whole job

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)